### PR TITLE
Switch node retrival to use `Machine` name

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,4 +52,3 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-      serviceAccountName: cloud-controller-manager

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.3.1
 	github.com/onsi/gomega v1.22.1
 	github.com/pkg/errors v0.9.1
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
@@ -104,6 +103,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.24.3 // indirect
 	k8s.io/apiserver v0.24.3 // indirect
 	k8s.io/component-helpers v0.24.3 // indirect

--- a/pkg/cloudprovider/onmetal/config.go
+++ b/pkg/cloudprovider/onmetal/config.go
@@ -26,10 +26,12 @@ import (
 )
 
 type onmetalCloudProviderConfig struct {
-	restConfig *rest.Config
+	RestConfig *rest.Config
+	Namespace  string
 }
 
 type CloudConfig struct {
+	Namespace  string `json:"namespace"`
 	Kubeconfig string `json:"kubeconfig"`
 }
 
@@ -43,6 +45,10 @@ func NewConfig(f io.Reader) (*onmetalCloudProviderConfig, error) {
 	cloudConfig := &CloudConfig{}
 	if err := yaml.Unmarshal(configBytes, cloudConfig); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal cloud config: %w", err)
+	}
+
+	if cloudConfig.Namespace == "" {
+		return nil, fmt.Errorf("namespace missing in cloud config")
 	}
 
 	if cloudConfig.Kubeconfig == "" {
@@ -65,6 +71,7 @@ func NewConfig(f io.Reader) (*onmetalCloudProviderConfig, error) {
 	klog.V(2).Infof("Successfully read configuration for cloud provider: %s", CloudProviderName)
 
 	return &onmetalCloudProviderConfig{
-		restConfig: restConfig,
+		RestConfig: restConfig,
+		Namespace:  cloudConfig.Namespace,
 	}, nil
 }

--- a/pkg/cloudprovider/onmetal/config_test.go
+++ b/pkg/cloudprovider/onmetal/config_test.go
@@ -23,7 +23,9 @@ import (
 
 var _ = Describe("Instances", func() {
 	const (
-		kubeconfigSample = `---
+		kubeconfigWrongSample = `---`
+		kubeconfigSample      = `---
+namespace: abcd
 kubeconfig: | 
   apiVersion: v1
   clusters:
@@ -46,10 +48,18 @@ kubeconfig: |
       client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBdXgzWUhkOElyRThGNTVVbzliS2w2bXQwb3pwVHFaUGpjSXJFWnpxakY4NjhEK05YCjNIOGtPMjdYNHJjMTlBMit0dmI4aVFpaDdTd1dRc0VGdnNaTTNwMEJLbEhnZjJDc3VzNVpCcU1vdE1rUjVZRDMKSVdGSFpKWXd3WGZoU0grWXBhL2NBTnFibTZONkNSdm9ubHVLWFlEYk9DbE9ON1VsbGdFVHhXRkpKSEM4bzQ2TAprVWFuWWZlWTlQSndNVlJBd0lJVWFXZE02cm5mS29UY0h2SjRNVWdqL2JKUm5YUDhqWGVucEU2QUdGUlpKT1RZCmdwQWk5K2IwWFg1ZlM1dE1BOHphbDNla29yUEQrSEJMK2VKbFVaN0dZRzJ3bzRpc3QvSUFWZjFoVEZReGFYSFIKd0Fzcnc0M2xmU3g3eTRjTlNmN0UvUDU3OVgzM29aZ2NvRjd0ZlFJREFRQUJBb0lCQUFHaTBDbnFza3UzWVNqVwpNQVo5Nmw5elV4QytTTTc1d1FwUjNFZSt4b0JGeVhVbUdyV04wd1pHQU5NMW9ONGlaS0Y2NVZoWlgva1A0cDN3CnpCa1A2TW9sZTBZZ2N5TUorRmlseHpkOG83VjQ4SlFlSFlzSUs3U2diNHF4ZnFIQW85Z0hBcGhyVU9MNmVlMnMKZGNzMHA3QUxtVjhUVldDOVQ3ZlJDSmc0TW9pRUEvNXZtK3FXZHlFLzFLSEdvbG1vSkx4clN1VlI5KytwZVhTOQptcWhRVGZtblNKcWs0RnhPNXRKd01YQnhmejg2MEJWbXlLQ3BLTlQzWVJDbFZBbVlqRlZrc1BMSnlQZWpNTzNDCnRiUVRybHZGL1lCWmlXMW5GeHY0OUtUdThoY0hvcXdrYVhJd0VOTUxVbEVHbE8rTUNrS3pNY0V6Umk0VkdsamwKSENMeFJ1RUNnWUVBMmI1ZXh3T2FmcXE3LzVvZVQzNGdkTVlIaDlqVHQvN0dqc0cxRjVTSThHWUNLcWd6ZHBCVApCZnh3WHhZNFBmZ2gzYkxNUFNobFRod20vVHVvUlE5a0w3cTJGSVp4MHlrYVNwVU9PbmFndVRFRVFoZHRXYUtjCmdNdHh0R2RacnJocU1oTmJ0cVFiNGxFbWliVlhqcXh5V1I5SjA2NUZtS3JyZlQyc1h4RHVlaGtDZ1lFQTIvM3YKdU5sei9mUUM2WUN2YjZZR2YxUkVXVnZyQ016d2xLdGFpU2dqdEgxclkwQklXUFZWTFY0VythT1BlTUVDRjBYcwp6MjBHM3FHVFJqTVZyMzJoQnQzYVRwQjR2MnBXcHZzQUJLYlRrblZWbDFnc3EzaHREMDFyNnBYcVJ1cTEyN0dqCkJkZkwvSTJYY3R1SS9ncUtTbVhzbGYxbG5sUkdWY0dKNGl3U1F3VUNnWUVBdCtrOU1DYnhCTys4WG9XVCtGeDEKbVd2eHpHSHRZVWxGK0NuUWhSd21GYlp6T2doYmYxY2phTGp4U0w4QnZnV294UkpSdzQ0dEVxNWdtQjhkWDBkQwp2YldjT1BYZGloYjdaK2RCMzB0M01UUWZmcHMrOXlpTHU1VWFjdCtnTmh6NVJWWm9ibmxxTzl1REMya3BqUTVHCmZ0UVlqVHh5K0NIVlNURWdPQ09hNlhFQ2dZRUFsYmIrd3dVeVBEMHBFakppc3BBQjBmdk9QQ1lqRVMwditXMlkKUXNtUGF4RUQyVnJ4SWFGczQyQXFNS0NRVG5URDhJVEZBZkZJQUpGamdoM1gvME4zS0E0cHVOZjNaUVdBalVrNgpuTy9RQXRkWmRaTXJhMUtjbmhKcGhBK2NqY0RFSFF5S1RycXE5MmlCRGtpN3RYQUU1MWJ3S0s5M3pjVzZ6RGZYCmw1VzRvK1VDZ1lBT1hYNkxYbXJ0aFI5c0RRa2RzMFkzK0sxS2xKbGU4WlFzbzJzbk5NbHE5a2pYVVFkR3BhanYKRU5CdHV0alMyaTFPbm9weEoxTVJPUzRUa2Z4TDRjZHoydjJYbUxXRUhNemtvVGdEOU1tS1lrdGd4ZStUWXdnUQo2MjVJK3N2c0ptR0xHZHE0aGNxaU9jNDdrTFl3RnozTkRBQXkvR0xSWUVBV0w1ajF1cE9Ub2c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
 	)
 
-	It("Should get instance info", func() {
+	It("Should read cloud config", func() {
 		reader := strings.NewReader(kubeconfigSample)
 		config, err := NewConfig(reader)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(config.restConfig).NotTo(BeNil())
+		Expect(config.RestConfig).NotTo(BeNil())
+		Expect(config.Namespace).NotTo(BeNil())
+	})
+
+	It("Should fail on empty cloud config", func() {
+		reader := strings.NewReader(kubeconfigWrongSample)
+		config, err := NewConfig(reader)
+		Expect(err).To(HaveOccurred())
+		Expect(config).To(BeNil())
 	})
 })

--- a/pkg/cloudprovider/onmetal/instances.go
+++ b/pkg/cloudprovider/onmetal/instances.go
@@ -29,20 +29,22 @@ import (
 )
 
 type onmetalInstances struct {
-	onmetalClient client.Client
 	targetClient  client.Client
+	onmetalClient client.Client
+	namespace     string
 }
 
-func newOnmetalInstances(onmetalClient client.Client, targetClient client.Client) cloudprovider.Instances {
+func newOnmetalInstances(targetClient client.Client, onmetalClient client.Client, namespace string) cloudprovider.Instances {
 	return &onmetalInstances{
-		onmetalClient: onmetalClient,
 		targetClient:  targetClient,
+		onmetalClient: onmetalClient,
+		namespace:     namespace,
 	}
 }
 
 func (o *onmetalInstances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]corev1.NodeAddress, error) {
-	klog.V(4).Infof("Getting node address for node: %s", nodeName)
-	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.targetClient, nodeName)
+	klog.V(4).Infof("Getting node addresses for node: %s", nodeName)
+	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.namespace, nodeName)
 	if apierrors.IsNotFound(err) {
 		return nil, cloudprovider.InstanceNotFound
 	}
@@ -86,7 +88,7 @@ func (o *onmetalInstances) NodeAddressesByProviderID(ctx context.Context, provid
 
 func (o *onmetalInstances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	klog.V(4).Infof("Getting instanceID for node: %s", nodeName)
-	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.targetClient, nodeName)
+	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.namespace, nodeName)
 	if apierrors.IsNotFound(err) {
 		return "", cloudprovider.InstanceNotFound
 	}
@@ -98,7 +100,7 @@ func (o *onmetalInstances) InstanceID(ctx context.Context, nodeName types.NodeNa
 
 func (o *onmetalInstances) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
 	klog.V(4).Infof("Getting instance type for node: %s", nodeName)
-	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.targetClient, nodeName)
+	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.namespace, nodeName)
 	if apierrors.IsNotFound(err) {
 		return "", cloudprovider.InstanceNotFound
 	}

--- a/pkg/cloudprovider/onmetal/instances_test.go
+++ b/pkg/cloudprovider/onmetal/instances_test.go
@@ -100,9 +100,6 @@ var _ = Describe("Instances", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: machine.Name,
 			},
-			Spec: corev1.NodeSpec{
-				ProviderID: fmt.Sprintf("%s://%s", CloudProviderName, machine.UID),
-			},
 		}
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
 
@@ -186,7 +183,7 @@ var _ = Describe("Instances", func() {
 		const wrongInstanceID = "12345"
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "my-node-",
+				GenerateName: "my-node-", // no matching machine should be available
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: fmt.Sprintf("%s://%s", wrongProvider, wrongInstanceID),
@@ -246,7 +243,7 @@ var _ = Describe("Instances", func() {
 		const wrongInstanceID = "12345"
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "my-node-",
+				GenerateName: "my-node-", // no matching machine should be available
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: fmt.Sprintf("%s://%s", CloudProviderName, wrongInstanceID),

--- a/pkg/cloudprovider/onmetal/instances_v2.go
+++ b/pkg/cloudprovider/onmetal/instances_v2.go
@@ -27,14 +27,16 @@ import (
 )
 
 type onmetalInstancesV2 struct {
-	onmetalClient client.Client
-	targetClient  client.Client
+	targetClient     client.Client
+	onmetalClient    client.Client
+	onmetalNamespace string
 }
 
-func newOnmetalInstancesV2(onmetalClient client.Client, targetClient client.Client) cloudprovider.InstancesV2 {
+func newOnmetalInstancesV2(targetClient client.Client, onmetalClient client.Client, namespace string) cloudprovider.InstancesV2 {
 	return &onmetalInstancesV2{
-		onmetalClient: onmetalClient,
-		targetClient:  targetClient,
+		targetClient:     targetClient,
+		onmetalClient:    onmetalClient,
+		onmetalNamespace: namespace,
 	}
 }
 
@@ -43,7 +45,7 @@ func (o *onmetalInstancesV2) InstanceExists(ctx context.Context, node *corev1.No
 		return false, nil
 	}
 	klog.V(4).Infof("Checking if instance exists for node: %s", node.Name)
-	_, err := GetMachineForNode(ctx, o.onmetalClient, o.targetClient, node)
+	_, err := GetMachineForNode(ctx, o.onmetalClient, o.onmetalNamespace, node)
 	if apierrors.IsNotFound(err) {
 		return false, cloudprovider.InstanceNotFound
 	}
@@ -58,7 +60,7 @@ func (o *onmetalInstancesV2) InstanceShutdown(ctx context.Context, node *corev1.
 		return false, nil
 	}
 	klog.V(4).Infof("Checking if instance is shut down for node: %s", node.Name)
-	machine, err := GetMachineForNode(ctx, o.onmetalClient, o.targetClient, node)
+	machine, err := GetMachineForNode(ctx, o.onmetalClient, o.onmetalNamespace, node)
 	if apierrors.IsNotFound(err) {
 		return false, cloudprovider.InstanceNotFound
 	}
@@ -73,7 +75,7 @@ func (o *onmetalInstancesV2) InstanceMetadata(ctx context.Context, node *corev1.
 	if node == nil {
 		return nil, nil
 	}
-	machine, err := GetMachineForNode(ctx, o.onmetalClient, o.targetClient, node)
+	machine, err := GetMachineForNode(ctx, o.onmetalClient, o.onmetalNamespace, node)
 	if apierrors.IsNotFound(err) {
 		return nil, cloudprovider.InstanceNotFound
 	}

--- a/pkg/cloudprovider/onmetal/instances_v2_test.go
+++ b/pkg/cloudprovider/onmetal/instances_v2_test.go
@@ -15,7 +15,6 @@
 package onmetal
 
 import (
-	"fmt"
 	"net/netip"
 
 	commonv1alpha1 "github.com/onmetal/onmetal-api/apis/common/v1alpha1"
@@ -98,9 +97,6 @@ var _ = Describe("InstancesV2", func() {
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: machine.Name,
-			},
-			Spec: corev1.NodeSpec{
-				ProviderID: fmt.Sprintf("%s://%s", CloudProviderName, machine.UID),
 			},
 		}
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())


### PR DESCRIPTION
# Proposed Changes

Previously we detected a `Machine` from the `Node`s `.spec.providerID`. As we can't ensure that this field is set, we are going to switch to a `Namespace/Name` symantic to access a `Nodes` `Machine` object.

Essentially the `Kubelet` will annouce its `hostname` as the node name. We will expect this heuristic to reflect the `Machine` name being the same as the `Machine`s hostname.
