### PR TITLE
Use `namespace` when getting `Machine` for UID

### DIFF
--- a/pkg/cloudprovider/onmetal/instances.go
+++ b/pkg/cloudprovider/onmetal/instances.go
@@ -29,22 +29,22 @@ import (
 )
 
 type onmetalInstances struct {
-	targetClient  client.Client
-	onmetalClient client.Client
-	namespace     string
+	targetClient     client.Client
+	onmetalClient    client.Client
+	onmetalNamespace string
 }
 
 func newOnmetalInstances(targetClient client.Client, onmetalClient client.Client, namespace string) cloudprovider.Instances {
 	return &onmetalInstances{
-		targetClient:  targetClient,
-		onmetalClient: onmetalClient,
-		namespace:     namespace,
+		targetClient:     targetClient,
+		onmetalClient:    onmetalClient,
+		onmetalNamespace: namespace,
 	}
 }
 
 func (o *onmetalInstances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]corev1.NodeAddress, error) {
 	klog.V(4).Infof("Getting node addresses for node: %s", nodeName)
-	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.namespace, nodeName)
+	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.onmetalNamespace, nodeName)
 	if apierrors.IsNotFound(err) {
 		return nil, cloudprovider.InstanceNotFound
 	}
@@ -76,7 +76,7 @@ func (o *onmetalInstances) NodeAddresses(ctx context.Context, nodeName types.Nod
 
 func (o *onmetalInstances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]corev1.NodeAddress, error) {
 	klog.V(4).Infof("Getting node address for providerID: %s", providerID)
-	machine, err := GetMachineForProviderID(ctx, o.onmetalClient, providerID)
+	machine, err := GetMachineForProviderID(ctx, o.onmetalClient, o.onmetalNamespace, providerID)
 	if apierrors.IsNotFound(err) {
 		return []corev1.NodeAddress{}, cloudprovider.InstanceNotFound
 	}
@@ -88,7 +88,7 @@ func (o *onmetalInstances) NodeAddressesByProviderID(ctx context.Context, provid
 
 func (o *onmetalInstances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	klog.V(4).Infof("Getting instanceID for node: %s", nodeName)
-	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.namespace, nodeName)
+	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.onmetalNamespace, nodeName)
 	if apierrors.IsNotFound(err) {
 		return "", cloudprovider.InstanceNotFound
 	}
@@ -100,7 +100,7 @@ func (o *onmetalInstances) InstanceID(ctx context.Context, nodeName types.NodeNa
 
 func (o *onmetalInstances) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
 	klog.V(4).Infof("Getting instance type for node: %s", nodeName)
-	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.namespace, nodeName)
+	machine, err := GetMachineForNodeName(ctx, o.onmetalClient, o.onmetalNamespace, nodeName)
 	if apierrors.IsNotFound(err) {
 		return "", cloudprovider.InstanceNotFound
 	}
@@ -125,7 +125,7 @@ func (o *onmetalInstances) CurrentNodeName(_ context.Context, hostName string) (
 
 func (o *onmetalInstances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
 	klog.V(4).Infof("Checking if instance exists for providerID: %s", providerID)
-	_, err := GetMachineForProviderID(ctx, o.onmetalClient, providerID)
+	_, err := GetMachineForProviderID(ctx, o.onmetalClient, o.onmetalNamespace, providerID)
 	if apierrors.IsNotFound(err) {
 		return false, cloudprovider.InstanceNotFound
 	}
@@ -137,7 +137,7 @@ func (o *onmetalInstances) InstanceExistsByProviderID(ctx context.Context, provi
 
 func (o *onmetalInstances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	klog.V(4).Infof("Checking if instance with providerID %s is shut down", providerID)
-	machine, err := GetMachineForProviderID(ctx, o.onmetalClient, providerID)
+	machine, err := GetMachineForProviderID(ctx, o.onmetalClient, o.onmetalNamespace, providerID)
 	if apierrors.IsNotFound(err) {
 		return false, cloudprovider.InstanceNotFound
 	}

--- a/pkg/cloudprovider/onmetal/utils.go
+++ b/pkg/cloudprovider/onmetal/utils.go
@@ -26,10 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetMachineForProviderID(ctx context.Context, c client.Client, providerID string) (*computev1alpha1.Machine, error) {
+func GetMachineForProviderID(ctx context.Context, c client.Client, namespace string, providerID string) (*computev1alpha1.Machine, error) {
 	machineUID := getMachineUIDFromProviderID(providerID)
 	machineList := &computev1alpha1.MachineList{}
-	if err := c.List(ctx, machineList, client.MatchingFields{
+	if err := c.List(ctx, machineList, client.InNamespace(namespace), client.MatchingFields{
 		machineMetadataUIDField: machineUID,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to get machine with UID %s: %w", machineUID, err)


### PR DESCRIPTION
# Proposed Changes

Restrict `Machine` listing operation by the `namespace` provided in the `cloud-config`.
