### PR TITLE
Update GH workflows and bump `envtest` k8s version to 1.28

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,16 +5,21 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
-          disable-releaser: github.ref != 'refs/heads/main'
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -2,7 +2,10 @@ name: Size Label
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types:
+      - opened
+      - edited
+      - synchronize
 
 jobs:
   size-label:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BIN_NAME = "cloud-provider-ironcore"
 IMG ?= controller:latest
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.0
+ENVTEST_K8S_VERSION = 1.28.0
 
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -57,6 +57,10 @@ docker-push:
 .PHONY: clean
 clean:
 	rm -rf ./dist/
+
+.PHONY: clean-local-bin
+clean-local-bin:
+	rm -rf $(LOCALBIN)/*
 
 ##@ Build Dependencies
 


### PR DESCRIPTION
# Proposed Changes

- Update GH workflows
- Bump `envtest` k8s version to 1.28
- Add `clean-local-bin` make directive to clean the local tools bin folder