### PR TITLE
 Bump golang to 1.22

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55.2
+          version: v1.56.2

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.13.0
-GOLANGCI_LINT_VERSION ?= v1.55.2
+GOIMPORTS_VERSION ?= v0.18.0
+GOLANGCI_LINT_VERSION ?= v1.56.2
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/cloud-provider-ironcore
 
-go 1.21
+go 1.22
 
 require (
 	github.com/ironcore-dev/controller-utils v0.9.2


### PR DESCRIPTION
# Proposed Changes

- Bump golang to 1.22
- Bump golangci-lint to v1.56.2
- Bump goimports to v0.18.0