### PR TITLE
Fix LoadBalancer port protocol assignment

### DIFF
--- a/pkg/cloudprovider/ironcore/load_balancer.go
+++ b/pkg/cloudprovider/ironcore/load_balancer.go
@@ -101,8 +101,9 @@ func (o *ironcoreLoadBalancer) EnsureLoadBalancer(ctx context.Context, clusterNa
 	klog.V(2).InfoS("Getting LoadBalancer ports from Service", "Service", client.ObjectKeyFromObject(service))
 	var lbPorts []networkingv1alpha1.LoadBalancerPort
 	for _, svcPort := range service.Spec.Ports {
+		protocol := svcPort.Protocol
 		lbPorts = append(lbPorts, networkingv1alpha1.LoadBalancerPort{
-			Protocol: &svcPort.Protocol,
+			Protocol: &protocol,
 			Port:     svcPort.Port,
 		})
 	}


### PR DESCRIPTION
# Proposed Changes

- The update modifies the way the protocol of each LoadBalancerPort is assigned. Instead of directly referencing the service's port protocol, a new variable is created for it. This change improves code clarity and helps avoid unexpected behavior due to mutable references.


Fixes #