### PR TITLE
Ignore `k8s.io/*` deps in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,28 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
     reviewers:
       - "ironcore-dev/integration"
+    # Ignore K8 packages as these are done manually
+    ignore:
+      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/apiextensions-apiserver"
+      - dependency-name: "k8s.io/apimachinery"
+      - dependency-name: "k8s.io/apiserver"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "k8s.io/component-base"
+      - dependency-name: "k8s.io/kube-aggregator"
+      - dependency-name: "k8s.io/kubectl"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
     reviewers:
       - "ironcore-dev/integration"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
     reviewers:
       - "ironcore-dev/integration"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.2
+          version: v1.58.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
 
 jobs:

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,7 +1,7 @@
 name: Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.18.0
-GOLANGCI_LINT_VERSION ?= v1.56.2
+GOIMPORTS_VERSION ?= v0.21.0
+GOLANGCI_LINT_VERSION ?= v1.58.0
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/cloud-provider-ironcore
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/ironcore-dev/controller-utils v0.9.3


### PR DESCRIPTION
# Proposed Changes

- Ignore `k8s.io/*` in dependabot configuration
- Bump golangci-lint to 1.58.0
- Bump `goimports` to 0.21.0
- Bump golang to 1.22.3