### PR TITLE
Improve logging in route controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BIN_NAME = "cloud-provider-ironcore"
 IMG ?= controller:latest
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.30.3
+ENVTEST_K8S_VERSION = 1.30.0
 
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin

--- a/pkg/cloudprovider/ironcore/suite_test.go
+++ b/pkg/cloudprovider/ironcore/suite_test.go
@@ -5,7 +5,10 @@ package ironcore
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -70,7 +73,15 @@ var _ = BeforeSuite(func() {
 	var err error
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{}
+	testEnv = &envtest.Environment{
+		// The BinaryAssetsDirectory is only required if you want to run the tests directly
+		// without call the makefile target test. If not informed it will look for the
+		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
+		// Note that you must have the required binaries setup under the bin directory to perform
+		// the tests directly. When we run make test it will be setup and used automatically.
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
+			fmt.Sprintf("1.30.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
 	testEnvExt = &envtestext.EnvironmentExtensions{
 		APIServiceDirectoryPaths: []string{
 			modutils.Dir("github.com/ironcore-dev/ironcore", "config", "apiserver", "apiservice", "bases"),


### PR DESCRIPTION
# Proposed Changes

- Improve logging in route controller. Addionally ensure that `envtest` is using the correct Kubernetes binaries.
- Fix the removal of a `Prefix` from a `NetworkInterface` in `DeleteRoute` method
