### PR TITLE
Use `NetworkInterfaceRef` in `Machine` status in `Route` controller

### DIFF
--- a/pkg/cloudprovider/ironcore/routes_test.go
+++ b/pkg/cloudprovider/ironcore/routes_test.go
@@ -379,12 +379,14 @@ var _ = Describe("Routes", func() {
 		machine.Status.State = computev1alpha1.MachineStateRunning
 		machine.Status.NetworkInterfaces = []computev1alpha1.NetworkInterfaceStatus{
 			{
-				Name: "primary",
-				IPs:  []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
+				Name:                "primary",
+				IPs:                 []commonv1alpha1.IP{commonv1alpha1.MustParseIP("100.0.0.1")},
+				NetworkInterfaceRef: corev1.LocalObjectReference{Name: staticNetworkInterface.Name},
 			},
 			{
-				Name: "ephemeral",
-				IPs:  []commonv1alpha1.IP{commonv1alpha1.MustParseIP("192.168.0.1")},
+				Name:                "ephemeral",
+				IPs:                 []commonv1alpha1.IP{commonv1alpha1.MustParseIP("192.168.0.1")},
+				NetworkInterfaceRef: corev1.LocalObjectReference{Name: ephemeralNetworkInterface.Name},
 			},
 		}
 		Expect(k8sClient.Patch(ctx, machine, client.MergeFrom(machineBase))).To(Succeed())


### PR DESCRIPTION
# Proposed Changes

Instead of using the a helper method to construct the name of a `NetworkInterface` which is attached to a `Machine` reply on the `Machine` status to get the correct NIC.