### PR TITLE
Use `networkInterfaceSelector` in `loadbalancerSpec`

### DIFF
--- a/pkg/cloudprovider/ironcore/config.go
+++ b/pkg/cloudprovider/ironcore/config.go
@@ -29,11 +29,13 @@ type CloudConfig struct {
 }
 
 var (
-	IroncoreKubeconfigPath string
+	IroncoreKubeconfigPath      string
+	loadbalancerWithNicSelector bool
 )
 
 func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&IroncoreKubeconfigPath, "ironcore-kubeconfig", "", "Path to the ironcore kubeconfig.")
+	fs.BoolVar(&loadbalancerWithNicSelector, "loadbalancer-with-nicselector", true, "loadbalancerSpec with networkinterfaceSelector having networkinterfaces labeled with LabelKeyClusterName: clusterName")
 }
 
 func LoadCloudProviderConfig(f io.Reader) (*cloudProviderConfig, error) {

--- a/pkg/cloudprovider/ironcore/config.go
+++ b/pkg/cloudprovider/ironcore/config.go
@@ -29,13 +29,13 @@ type CloudConfig struct {
 }
 
 var (
-	IroncoreKubeconfigPath      string
-	loadbalancerWithNicSelector bool
+	IroncoreKubeconfigPath string
+	useNicSelector         bool
 )
 
 func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&IroncoreKubeconfigPath, "ironcore-kubeconfig", "", "Path to the ironcore kubeconfig.")
-	fs.BoolVar(&loadbalancerWithNicSelector, "loadbalancer-with-nicselector", true, "loadbalancerSpec with networkinterfaceSelector having networkinterfaces labeled with LabelKeyClusterName: clusterName")
+	fs.BoolVar(&useNicSelector, "use-nic-selector", true, "loadbalancerSpec with networkinterfaceSelector having networkinterfaces labeled with LabelKeyClusterName: clusterName")
 }
 
 func LoadCloudProviderConfig(f io.Reader) (*cloudProviderConfig, error) {

--- a/pkg/cloudprovider/ironcore/load_balancer.go
+++ b/pkg/cloudprovider/ironcore/load_balancer.go
@@ -186,7 +186,7 @@ func (o *ironcoreLoadBalancer) EnsureLoadBalancer(ctx context.Context, clusterNa
 		}
 	}
 	// If loadbalancerWithNicSelector is set to true then add NetworkInterfaceSelector to loadbalancer.SPec
-	if loadbalancerWithNicSelector {
+	if o.loadbalancerWithNicSelector {
 		loadBalancer.Spec.NetworkInterfaceSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				LabelKeyClusterName: clusterName,
@@ -202,7 +202,7 @@ func (o *ironcoreLoadBalancer) EnsureLoadBalancer(ctx context.Context, clusterNa
 
 	// if loadbalancerWithNicSelector is set to false then cloudProvider has to create the loadbalancerRouting
 	// if loadbalancerWithNicSelector is set to true then Ironcore will take care of creating the loadbalancerRouting
-	if !loadbalancerWithNicSelector {
+	if !o.loadbalancerWithNicSelector {
 		klog.V(2).InfoS("Applying LoadBalancerRouting for LoadBalancer", "LoadBalancer", client.ObjectKeyFromObject(loadBalancer))
 		if err := o.applyLoadBalancerRoutingForLoadBalancer(ctx, loadBalancer, nodes); err != nil {
 			return nil, err
@@ -356,7 +356,7 @@ func (o *ironcoreLoadBalancer) UpdateLoadBalancer(ctx context.Context, clusterNa
 	if err := o.ironcoreClient.Get(ctx, loadBalancerKey, loadBalancer); err != nil {
 		return fmt.Errorf("failed to get LoadBalancer %s: %w", client.ObjectKeyFromObject(loadBalancer), err)
 	}
-	if !loadbalancerWithNicSelector {
+	if !o.loadbalancerWithNicSelector {
 		loadBalancerRouting := &networkingv1alpha1.LoadBalancerRouting{}
 		loadBalancerRoutingKey := client.ObjectKey{Namespace: o.ironcoreNamespace, Name: loadBalancerName}
 		if err := o.ironcoreClient.Get(ctx, loadBalancerRoutingKey, loadBalancerRouting); err != nil {


### PR DESCRIPTION
# Proposed Changes

- Add `networkInterfaceSelector` in `loadbalancerSpec`
- Add a flag-based approach to handle `loadbalancer` and `loadbalancerRouting` with or without `networkInterfaceSelector`
- validate the changes with testcases

Fixes #486 