### PR TITLE
Bump golangci-lint to v2.4 and update lint GH action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        run: make lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: 2.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: 2.4
+          version: v2.4

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
 GOIMPORTS_VERSION ?= v0.31.0
-GOLANGCI_LINT_VERSION ?= v2.1
+GOLANGCI_LINT_VERSION ?= v2.4
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)


### PR DESCRIPTION
# Proposed Changes

- Bump golangci-lint to v2.4
- Replace 'make lint' with GH action
