### PR TITLE
Derive Zone and region metadata from pool topology labels instead of annotations

### DIFF
--- a/pkg/cloudprovider/ironcore/instances_v2.go
+++ b/pkg/cloudprovider/ironcore/instances_v2.go
@@ -144,9 +144,19 @@ func (o *ironcoreInstancesV2) InstanceMetadata(ctx context.Context, node *corev1
 		return nil, fmt.Errorf("failed to get machine pool %s for machine %s: %w", machine.Spec.MachinePoolRef.Name, machine.Name, err)
 	}
 
-	zone, ok := pool.Annotations[string(v1alpha1.TopologyLabelZone)]
-	if !ok {
+	zone, ok := pool.Labels[string(v1alpha1.TopologyLabelZone)]
+	if ok {
+		klog.V(2).InfoS("Resolved zone from pool topology label", "Machine", machine.Name, "Pool", pool.Name, "Zone", zone)
+	} else {
 		zone = pool.Name
+		klog.V(2).InfoS("Pool topology label not found, deriving zone from pool name (legacy behavior)", "Machine", machine.Name, "Pool", pool.Name, "Zone", zone)
+	}
+
+	region := pool.Labels[string(v1alpha1.TopologyLabelRegion)]
+	if region != "" {
+		klog.V(2).InfoS("Resolved region from pool topology label", "Machine", machine.Name, "Pool", pool.Name, "Region", region)
+	} else {
+		klog.V(2).InfoS("Pool topology region label not found", "Machine", machine.Name, "Pool", pool.Name)
 	}
 
 	return &cloudprovider.InstanceMetadata{
@@ -154,6 +164,6 @@ func (o *ironcoreInstancesV2) InstanceMetadata(ctx context.Context, node *corev1
 		InstanceType:  machine.Spec.MachineClassRef.Name,
 		NodeAddresses: addresses,
 		Zone:          zone,
-		Region:        pool.Annotations[string(v1alpha1.TopologyLabelRegion)],
+		Region:        region,
 	}, nil
 }

--- a/pkg/cloudprovider/ironcore/instances_v2_test.go
+++ b/pkg/cloudprovider/ironcore/instances_v2_test.go
@@ -212,17 +212,17 @@ var _ = Describe("InstancesV2", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("should return zone and region from machine pool annotations", func(ctx SpecContext) {
+	It("should return zone and region from machine pool labels", func(ctx SpecContext) {
 		By("instantiating the instances v2 provider")
 		var ok bool
 		instancesProvider, ok = (*cp).InstancesV2()
 		Expect(ok).To(BeTrue())
 
-		By("creating a machine pool with zone and region annotations")
+		By("creating a machine pool with zone and region labels")
 		machinePool := &computev1alpha1.MachinePool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pool-with-zone-region",
-				Annotations: map[string]string{
+				Labels: map[string]string{
 					string(commonv1alpha1.TopologyLabelZone):   "eu-west-1a",
 					string(commonv1alpha1.TopologyLabelRegion): "eu-west-1",
 				},
@@ -231,7 +231,7 @@ var _ = Describe("InstancesV2", func() {
 		Expect(k8sClient.Create(ctx, machinePool)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, machinePool)
 
-		By("creating a machine referencing the annotated pool")
+		By("creating a machine referencing the labeled pool")
 		machine := &computev1alpha1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    ns.Name,
@@ -300,24 +300,24 @@ var _ = Describe("InstancesV2", func() {
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, node)
 
-		By("ensuring that instance metadata returns zone and region from pool annotations")
+		By("ensuring that instance metadata returns zone and region from pool labels")
 		instanceMetadata, err := instancesProvider.InstanceMetadata(ctx, node)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(instanceMetadata.Zone).To(Equal("eu-west-1a"))
 		Expect(instanceMetadata.Region).To(Equal("eu-west-1"))
 	})
 
-	It("should return zone from annotation and empty region when only zone annotation is set", func(ctx SpecContext) {
+	It("should return zone from label and empty region when only zone label is set", func(ctx SpecContext) {
 		By("instantiating the instances v2 provider")
 		var ok bool
 		instancesProvider, ok = (*cp).InstancesV2()
 		Expect(ok).To(BeTrue())
 
-		By("creating a machine pool with only zone annotation")
+		By("creating a machine pool with only zone label")
 		machinePool := &computev1alpha1.MachinePool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pool-zone-only",
-				Annotations: map[string]string{
+				Labels: map[string]string{
 					string(commonv1alpha1.TopologyLabelZone): "us-east-1b",
 				},
 			},
@@ -394,7 +394,7 @@ var _ = Describe("InstancesV2", func() {
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, node)
 
-		By("ensuring that instance metadata returns zone from annotation and empty region")
+		By("ensuring that instance metadata returns zone from label and empty region")
 		instanceMetadata, err := instancesProvider.InstanceMetadata(ctx, node)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(instanceMetadata.Zone).To(Equal("us-east-1b"))


### PR DESCRIPTION
# Proposed Changes

The topology information was wrongly extracted from `metadata.annotations` instead of `labels`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Zone and region metadata is now derived from pool topology labels instead of annotations, with fallback support for zone values when labels are unavailable

* **Tests**
  * Updated and expanded test suite to validate label-based topology resolution across multiple scenarios, including zone and region labels, zone-only labels, and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->