### PR TITLE
Remove `paths-ignore` filters from required workflows

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -3,9 +3,6 @@ name: Check
 on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   checks:

--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -3,9 +3,6 @@ name: Kustomize Validation
 on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   kustomize-validation:


### PR DESCRIPTION
# Proposed Changes

- Remove path-ignore from triggers of required workflows so they do not block
  PRs




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Pull requests that modify documentation or Markdown files now run the standard checks.
  - Kustomize validation is now triggered for documentation and Markdown-only pull requests.
  - Kustomize validation now explicitly runs the project’s validation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->