### PR TITLE
Fix deprecations in kustomizations

### DIFF
--- a/config/config/kustomization.yaml
+++ b/config/config/kustomization.yaml
@@ -1,3 +1,5 @@
-resources:
-  - secret.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 
+resources:
+- secret.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,7 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 namespace: kube-system
 
 resources:
-#  - ../rbac
-#  - ../config
-  - ../manager
-
+- ../manager

--- a/config/kind/kustomization.yaml
+++ b/config/kind/kustomization.yaml
@@ -1,21 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 namespace: kube-system
 
 resources:
-  - ../default
-  - ../rbac
+- ../default
+- ../rbac
 
-patchesStrategicMerge:
-  - patch-manager.yaml
+patches:
+- path: patch-manager.yaml
 
 # cluster api + infra is essentially the same environment (kind cluster)
 secretGenerator:
-  - name: kubeconfig
-    files:
-      - kubeconfig
-  - name: cloud-config
-    files:
-      - cloud-config
-  - name: ironcore-kubeconfig
-    files:
-      - ironcore/kubeconfig
-
+- files:
+  - kubeconfig
+  name: kubeconfig
+- files:
+  - cloud-config
+  name: cloud-config
+- files:
+  - ironcore/kubeconfig
+  name: ironcore-kubeconfig

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
-  - manager.yaml
+- manager.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,7 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
-  - service_account.yaml
-  - cluster_role.yaml
-  - cluster_role_binding.yaml
-  - role.yaml
-  - role_binding.yaml
-  - leader_election_role.yaml
+- service_account.yaml
+- cluster_role.yaml
+- cluster_role_binding.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml


### PR DESCRIPTION

Fixes #589  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Kubernetes Kustomize manifests with explicit API versions and resource types.
  * Updated deployment configuration to target the `kube-system` namespace.
  * Modernized patch configuration and secret file declarations for improved compatibility with current Kustomize tooling.
  * Simplified the default deployment resource selection.
  * Reformatted RBAC resource definitions without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->