### PR TITLE
Bump kustomize versions

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v7
       - uses: imranismail/setup-kustomize@v3
         with:
-          kustomize-version: '5.0.0'
+          kustomize-version: '5.7.1'
       - run: |
           ./hack/validate-kustomize.sh


### PR DESCRIPTION
- to what is bundled with kubectl 1.34.x and 1.35.x

Fixes #589 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kustomize validation tooling to version 5.7.1.
  * No changes to application functionality or validation workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->